### PR TITLE
PROCESSING-4060: Token fetching should not restart backoff. Retries s…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -41,3 +41,7 @@ History
 * Modifying setup.cfg to allow different version formats (i.e development versions)
 * Paging with `continue` parameter
 * When token is expired, it is updated automatically with CLIENT_GRANT auth type
+
+2.1.1 (2019-10-02)
+------------------
+* Token fetching not restarting backoff. Retries continuing its count instead of restarting it when there is a invalid token

--- a/sequoia/__init__.py
+++ b/sequoia/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 __description__ = """Sequoia Python Client SDK"""
 __url__ = "https://github.com/pikselpalette/sequoia-python-client-sdk"
 __author__ = 'Piksel'

--- a/sequoia/http.py
+++ b/sequoia/http.py
@@ -131,7 +131,7 @@ class HttpExecutor:
         try:
             # This can raise AuthorisationError and should not be retried
             self.session.auth.update_token()
-            return self.request(*request_args, **request_kwargs)
+            return self._request(*request_args, **request_kwargs)
         except NotImplementedError:
             # Auth type does not provide refresh_token
             self._raise_sequoia_error(response)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.1.1
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ _KEYWORDS = ' '.join([
 
 setup(
     name='sequoia-client-sdk',
-    version='2.1.0',
+    version='2.1.1',
     description=sequoia.__description__,
     long_description=_LONG_DESCRIPTION,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
PROCESSING-4060: Token fetching should not restart backoff. Retries should continue its count instead of restarting it