### PR TITLE
PROCESSING-4253: Adding token cache

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -49,3 +49,4 @@ History
 2.2.0 (XXXX-XX-XX)
 ------------------
 * Allowing to provide `correlation_id` value when the client is created
+* Caching tokens by `grant_client_id` and `token_url` to avoid calling identity in case credentials are cached

--- a/sequoia/auth.py
+++ b/sequoia/auth.py
@@ -72,28 +72,17 @@ class Auth:
 
 
 class TokenCache:
-    class __OnlyOne:
+    _token_storage = {}
 
-        _token_storage = {}
+    def get_token(self, grant_client_id, token_url):
+        if grant_client_id in self._token_storage and token_url in self._token_storage[grant_client_id]:
+            return self._token_storage[grant_client_id][token_url]
+        return None
 
-        def get_token(self, grant_client_id, token_url):
-            if grant_client_id in self._token_storage and token_url in self._token_storage[grant_client_id]:
-                return self._token_storage[grant_client_id][token_url]
-            return None
-
-        def add_token(self, grant_client_id, token_url, token):
-            if grant_client_id not in self._token_storage:
-                self._token_storage[grant_client_id] = {}
-            self._token_storage[grant_client_id][token_url] = token
-
-    instance = None
-
-    def __init__(self):
-        if not TokenCache.instance:
-            TokenCache.instance = TokenCache.__OnlyOne()
-
-    def __getattr__(self, name):
-        return getattr(self.instance, name)
+    def add_token(self, grant_client_id, token_url, token):
+        if grant_client_id not in self._token_storage:
+            self._token_storage[grant_client_id] = {}
+        self._token_storage[grant_client_id][token_url] = token
 
 
 class ClientGrantAuth(Auth):

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -1,0 +1,64 @@
+import unittest
+
+from hamcrest import assert_that, is_
+
+from sequoia.auth import TokenCache, ClientGrantAuth
+
+
+class TestClientGrantAuth(unittest.TestCase):
+    def setUp(self):
+        TokenCache._token_storage = {}
+
+    def test_given_token_is_not_provided_and_it_is_not_in_cache_then_token_is_none(self):
+        auth = ClientGrantAuth('user', 'pass', 'http://identity')
+        assert_that(auth.token, is_(None))
+
+    def test_given_token_is_provided_then_that_token_is_used_and_added_to_cache(self):
+        auth = ClientGrantAuth('user', 'pass', 'http://identity', '1234')
+        assert_that(auth.token, is_({'token_type': 'bearer', 'access_token': '1234'}))
+        assert_that(TokenCache._token_storage,
+                    is_({'user': {'http://identity': {'token_type': 'bearer', 'access_token': '1234'}}}))
+
+    def test_given_token_is_not_provided_and_there_is_a_token_in_cache_then_that_token_is_used(self):
+        TokenCache().add_token('user', 'http://identity', {'token_type': 'bearer', 'access_token': '567'})
+        auth = ClientGrantAuth('user', 'pass', 'http://identity')
+        assert_that(auth.token, is_({'token_type': 'bearer', 'access_token': '567'}))
+
+    def test_given_token_is_not_provided_and_it_is_not_in_cache_then_token_is_fetched_and_added_to_cache(self):
+        class MockSession:
+            def __init__(self):
+                self.token = {'token_type': 'bearer', 'access_token': '789'}
+
+            def fetch_token(self, *args, **kwargs):
+                pass
+
+        auth = ClientGrantAuth('user', 'pass', 'http://identity')
+        auth.session = MockSession()
+        auth.init_session()
+
+        assert_that(TokenCache._token_storage,
+                    is_({'user': {'http://identity': {'token_type': 'bearer', 'access_token': '789'}}}))
+
+
+class TestTokenCache(unittest.TestCase):
+
+    def setUp(self):
+        TokenCache._token_storage = {}
+
+    def test_given_a_token_it_is_added_to_cache(self):
+        assert_that(TokenCache._token_storage, is_({}))
+
+        TokenCache().add_token('user-1', 'url1', '123')
+        TokenCache().add_token('user-1', 'url2', '456')
+        TokenCache().add_token('user-2', 'url1', '789')
+
+        assert_that(TokenCache._token_storage,
+                    is_({'user-1': {'url1': '123', 'url2': '456'}, 'user-2': {'url1': '789'}}))
+
+        assert_that(TokenCache().get_token('user-1', 'url1'), is_('123'))
+        assert_that(TokenCache().get_token('user-1', 'url2'), is_('456'))
+        assert_that(TokenCache().get_token('user-1', 'url3'), is_(None))
+        assert_that(TokenCache().get_token('user-2', 'url1'), is_('789'))
+        assert_that(TokenCache().get_token('user-3', 'url1'), is_(None))
+
+        TokenCache._token_storage = {}

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -10,6 +10,7 @@ from requests import Response
 
 from sequoia import criteria, auth
 from sequoia import error
+from sequoia.auth import TokenCache
 from sequoia.client import Client, ResponseBuilder
 from sequoia.criteria import Criteria, Inclusion
 from tests import mocking
@@ -442,6 +443,7 @@ class TestBusinessEndpointProxy(unittest.TestCase):
 class TestClient(unittest.TestCase):
     def setUp(self):
         self.mock = mocking.bootstrap_mock()
+        TokenCache._token_storage = {}
 
     def test_fetch_token_given_there_is_an_error_fetching_the_token_then_client_error_is_raised(self):
         mocking.add_post_mapping_for(self.mock, 'identity', 'error_identity_response')


### PR DESCRIPTION
Caching tokens by `grant_client_id` and `token_url` to avoid calling identity in case credentials are cached
