### PR TITLE
Processing 4545 duplicated queries with generator

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -50,3 +50,4 @@ History
 ------------------
 * Allowing to provide `correlation_id` value when the client is created
 * Caching tokens by `grant_client_id` and `token_url` to avoid calling identity in case credentials are cached
+* PageBrowser keeping a response cache to avoid duplicated requests

--- a/sequoia/client.py
+++ b/sequoia/client.py
@@ -233,14 +233,6 @@ class LinkedResourcesPageBrowser(object):
                     for next_item_page in next_items_page_browser:
                         yield next_item_page.resources
 
-    def return_next_items_linked_to_main_page(self, next_items):
-        for next_item in next_items:
-            next_items_page_browser = PageBrowser(endpoint=self._endpoint, resource_name=self._resource,
-                                                  query_string=urlparse(next_item).query,
-                                                  params={'owner': self._owner})
-            for page in next_items_page_browser:
-                yield page.resources
-
     def _next_fields_in_linked_resources(self):
         return [linked_item['next'] for linked_item in self._linked_links() if self._next_in_linked_item(linked_item)]
 

--- a/sequoia/client.py
+++ b/sequoia/client.py
@@ -314,8 +314,8 @@ class PageBrowser(object):
         cache_index = 0
         while cache_index < len(self._response_cache) or self.next_url:
             if cache_index < len(self._response_cache):
+                yield self._response_cache[cache_index]
                 cache_index += 1
-                yield self._response_cache[cache_index - 1]
 
             if self.next_url:
                 self.next_url, response = self._fetch(self.next_url)

--- a/sequoia/client.py
+++ b/sequoia/client.py
@@ -305,10 +305,6 @@ class PageBrowser(object):
     def linked(self, resource):
         return LinkedResourcesPageBrowser(self._endpoint, self, resource, self.params.get('owner'))
 
-    def _iterator_state(self):
-        return {'response_cache': self._response_cache,
-                'next_url': self.next_url}
-
     def __getattr__(self, name):
         if self._response_cache:
             return getattr(self._response_cache[0], name)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -120,7 +120,6 @@ class TestResourceEndpointProxy(unittest.TestCase):
         under_test_browse = under_test.browse('testmock', query_string='continue=true&perPage=2')
 
         response_list = [response for response in under_test_browse]
-        response_list_2 = [response for response in under_test_browse]
 
         assert_that(response_list, has_length(3))
         assert_that(response_list[0].resources, has_length(2))

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -26,6 +26,7 @@ logging.basicConfig(level=logging.DEBUG)
 class TestResourceEndpointProxy(unittest.TestCase):
 
     def setUp(self):
+        TokenCache._token_storage = {}
         self.mock = mocking.bootstrap_mock()
         self.client = Client('http://mock-registry/services/testmock',
                              grant_client_id='piksel-workflow',
@@ -182,6 +183,17 @@ class TestResourceEndpointProxy(unittest.TestCase):
         assert_that(len(offers_linked_pages[0]), is_(100))
         assert_that(len(offers_linked_pages[1]), is_(1))
 
+        expected_requests = [{'path': '/services/testmock', 'query': ''},
+                             {'path': '/oauth/token', 'query': ''},
+                             {'path': '/data/contents', 'query': 'include=assets,offers&owner=testmock'},
+                             {'path': '/data/assets',
+                              'query': 'fields=ref%2cname%2ccontentref%2ctype%2cmediatype%2curl%2cfileformat%2ctitle%2cfilesize%2ctags&count=true&withcontentref=test%3acontentstochecktesting1&page=2&perpage=100&owner=testmock'},
+                             {'path': '/data/offers',
+                              'query': 'fields=ref%2cname%2ctitle%2ccontentrefs&count=true&withcontentrefs=test%3acontentstochecktesting1&page=2&perpage=100&owner=testmock'}]
+
+        performed_requests = [{'path': r.path, 'query': r.query} for r in self.mock.request_history]
+        assert_that(performed_requests, is_(expected_requests))
+
     def test_browse_linked_resources_without_inclusions_then_returns_mocked_assets(self):
         mocking.add_get_mapping_for_url(self.mock,
                                         'data/contents\?owner=testmock',
@@ -218,18 +230,6 @@ class TestResourceEndpointProxy(unittest.TestCase):
                                         'data/contents\?include=assets&owner=testmock&page=3&perPage=100',
                                         'pagination_main_third_page')
 
-        mocking.add_get_mapping_for_url(self.mock,
-                                        '/data/assets\?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&count=true&withContentRef=testmock%3A0968d155-77ec-450c-ae68-47f8936e2121%7C%7Ctestmock%3A1f62e6bb-b995-4b50-be1e-9825dfecb275%7C%7Ctestmock%3A4569ad10-3912-42a1-b769-83456e69ae50%7C%7Ctestmock%3A5cc87697-bab8-4776-89a4-a788dc7acdda%7C%7Ctestmock%3A73601df6-9b99-4008-b6b1-4ccc80b93cfe%7C%7Ctestmock%3A92e7f35c-5b9b-41e1-ae4f-bbda1d89f0e1%7C%7Ctestmock%3AY3JpZDovL2JiYy5jby51ay8yODk0MDA0MjI%7C%7Ctestmock%3AY3JpZDovL2JiYy5jby51ay8yODk0MDA0MjM%7C%7Ctestmock%3Aba01f7f2-17c8-4775-8934-ceb2f3a0f810%7C%7Ctestmock%3Ad5b61cb8-955a-4f34-ad60-a1b22a240077&page=2&perPage=100',
-                                        'pagination_second_page')
-
-        mocking.add_get_mapping_for_url(self.mock,
-                                        'data/assets\?count=true&fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&owner=testmock&page=3&perPage=100&withContentRef=testmock%3A0968d155-77ec-450c-ae68-47f8936e2121%7C%7Ctestmock%3A1f62e6bb-b995-4b50-be1e-9825dfecb275%7C%7Ctestmock%3A4569ad10-3912-42a1-b769-83456e69ae50%7C%7Ctestmock%3A5cc87697-bab8-4776-89a4-a788dc7acdda%7C%7Ctestmock%3A73601df6-9b99-4008-b6b1-4ccc80b93cfe%7C%7Ctestmock%3A92e7f35c-5b9b-41e1-ae4f-bbda1d89f0e1%7C%7Ctestmock%3AY3JpZDovL2JiYy5jby51ay8yODk0MDA0MjI%7C%7Ctestmock%3AY3JpZDovL2JiYy5jby51ay8yODk0MDA0MjM%7C%7Ctestmock%3Aba01f7f2-17c8-4775-8934-ceb2f3a0f810%7C%7Ctestmock%3Ad5b61cb8-955a-4f34-ad60-a1b22a240077',
-                                        'pagination_third_page')
-
-        mocking.add_get_mapping_for_url(self.mock,
-                                        'data/assets\?fields=ref%2Cname%2CcontentRef%2Ctype%2Curl%2CfileFormat%2Ctitle%2CfileSize%2Ctags&withContentRef=testmock%3A0968d155-77ec-450c-ae68-47f8936e2121%7C%7Ctestmock%3A1f62e6bb-b995-4b50-be1e-9825dfecb275%7C%7Ctestmock%3A4569ad10-3912-42a1-b769-83456e69ae50%7C%7Ctestmock%3A5cc87697-bab8-4776-89a4-a788dc7acdda%7C%7Ctestmock%3A73601df6-9b99-4008-b6b1-4ccc80b93cfe%7C%7Ctestmock%3A92e7f35c-5b9b-41e1-ae4f-bbda1d89f0e1%7C%7Ctestmock%3AY3JpZDovL2JiYy5jby51ay8yODk0MDA0MjI%7C%7Ctestmock%3AY3JpZDovL2JiYy5jby51ay8yODk0MDA0MjM%7C%7Ctestmock%3Aba01f7f2-17c8-4775-8934-ceb2f3a0f810%7C%7Ctestmock%3Ad5b61cb8-955a-4f34-ad60-a1b22a240077&page=3&perPage=100',
-                                        'pagination_third_page')
-
         under_test = self.client.metadata.contents
 
         contents_response = under_test.browse('testmock', query_string='include=assets')
@@ -246,7 +246,52 @@ class TestResourceEndpointProxy(unittest.TestCase):
         assert_that(len(asset_linked_pages[1]), is_(157))
         assert_that(len(asset_linked_pages[2]), is_(46))
 
-        assert_that(self.mock.call_count, is_(5))
+        expected_requests = [{'path': '/services/testmock', 'query': ''},
+                             {'path': '/oauth/token', 'query': ''},
+                             {'path': '/data/contents', 'query': 'include=assets&owner=testmock'},
+                             {'path': '/data/contents', 'query': 'include=assets&owner=testmock&page=2&perpage=100'},
+                             {'path': '/data/contents', 'query': 'include=assets&owner=testmock&page=3&perpage=100'}]
+
+        performed_requests = [{'path': r.path, 'query': r.query} for r in self.mock.request_history]
+        assert_that(performed_requests, is_(expected_requests))
+
+    def test_browse_linked_resources_with_prefetch_and_more_than_one_page_goes_throw_several_pages(self):
+        mocking.add_get_mapping_for_url(self.mock,
+                                        'data/contents\?include=assets&owner=testmock',
+                                        'pagination_main_page')
+
+        mocking.add_get_mapping_for_url(self.mock,
+                                        'data/contents\?include=assets&owner=testmock&page=2&perPage=100',
+                                        'pagination_main_second_page')
+
+        mocking.add_get_mapping_for_url(self.mock,
+                                        'data/contents\?include=assets&owner=testmock&page=3&perPage=100',
+                                        'pagination_main_third_page')
+
+        under_test = self.client.metadata.contents
+
+        contents_response = under_test.browse('testmock', query_string='include=assets', prefetch_pages=3)
+
+        asset_linked = contents_response.linked('assets')
+
+        assert_that(contents_response.resources, has_length(100))
+        assert_that(contents_response.resources[0]['name'], is_('0968d155-77ec-450c-ae68-47f8936e2121'))
+        assert_that(len(asset_linked.resources), is_(100))
+        assert_that(asset_linked.resources[50]['name'], is_('437366a3-a2c5-4633-803c-72dfcb4366f4'))
+
+        asset_linked_pages = [page for page in contents_response.linked('assets')]
+        assert_that(len(asset_linked_pages[0]), is_(100))
+        assert_that(len(asset_linked_pages[1]), is_(157))
+        assert_that(len(asset_linked_pages[2]), is_(46))
+
+        expected_requests = [{'path': '/services/testmock', 'query': ''},
+                             {'path': '/oauth/token', 'query': ''},
+                             {'path': '/data/contents', 'query': 'include=assets&owner=testmock'},
+                             {'path': '/data/contents', 'query': 'include=assets&owner=testmock&page=2&perpage=100'},
+                             {'path': '/data/contents', 'query': 'include=assets&owner=testmock&page=3&perpage=100'}]
+
+        performed_requests = [{'path': r.path, 'query': r.query} for r in self.mock.request_history]
+        assert_that(performed_requests, is_(expected_requests))
 
     def test_browse_assets_with_paging_returns_mocked_assets(self):
         mocking.add_get_mapping_for_url(self.mock,

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -246,6 +246,8 @@ class TestResourceEndpointProxy(unittest.TestCase):
         assert_that(len(asset_linked_pages[1]), is_(157))
         assert_that(len(asset_linked_pages[2]), is_(46))
 
+        assert_that(self.mock.call_count, is_(5))
+
     def test_browse_assets_with_paging_returns_mocked_assets(self):
         mocking.add_get_mapping_for_url(self.mock,
                                         'data/assets\?withContentRef=theContentRef&perPage=2&owner=testmock',

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -117,9 +117,11 @@ class TestResourceEndpointProxy(unittest.TestCase):
 
         under_test = self.client.metadata.contents
 
-        response_list = [response
-                         for response in under_test.browse('testmock',
-                                                           query_string='continue=true&perPage=2')]
+        under_test_browse = under_test.browse('testmock', query_string='continue=true&perPage=2')
+
+        response_list = [response for response in under_test_browse]
+        response_list_2 = [response for response in under_test_browse]
+
         assert_that(response_list, has_length(3))
         assert_that(response_list[0].resources, has_length(2))
         assert_that(response_list[1].resources, has_length(2))


### PR DESCRIPTION
PROCESSING-4545: Main page is requested to know linked resources data, so that page should not be requested again when iterating over linked assets. 

PageBrowser keeping responses in a cache. Moving from iterator to generator.