### PR TITLE
Metaflow 123 token refresh

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -66,3 +66,9 @@ History
 * Python 3.8 supported
 * Pagination with `continue` parameter over linked resources supported
 * Requirements upgraded
+
+4.0.1 (2020-12-22)
+------------------
+* When token is expired, it is updated automatically with CLIENT_GRANT auth type,
+    the 401 response wasn't managed to do so, only the exception was.
+    Now the 401 response is treated like that.

--- a/sequoia/__init__.py
+++ b/sequoia/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '4.0.0'
+__version__ = '4.0.1'
 __description__ = """Sequoia Python Client SDK"""
 __url__ = "https://github.com/pikselpalette/sequoia-python-client-sdk"
 __author__ = 'Piksel'

--- a/sequoia/http.py
+++ b/sequoia/http.py
@@ -131,6 +131,12 @@ class HttpExecutor:
             return self.request(method, response.headers['location'], data=data, params=params, headers=request_headers,
                                 retry_count=retry_count, resource_name=resource_name)
 
+        if response.status_code == 401:
+            logging.info('Updating token and retrying request')
+            return self._update_token_and_retry_request(method, url, data=data, params=params,
+                                                        headers=request_headers, retry_count=retry_count,
+                                                        resource_name=resource_name)
+
         if 400 <= response.status_code <= 600:
             self._raise_sequoia_error(response)
 

--- a/sequoia/http.py
+++ b/sequoia/http.py
@@ -10,6 +10,7 @@ from requests.exceptions import RequestException, ConnectionError, Timeout, TooM
 
 from sequoia import __version__ as client_version, util
 from sequoia import error, env
+from sequoia.auth import BYOTokenAuth
 
 try:
     from distro import linux_distribution
@@ -131,7 +132,7 @@ class HttpExecutor:
             return self.request(method, response.headers['location'], data=data, params=params, headers=request_headers,
                                 retry_count=retry_count, resource_name=resource_name)
 
-        if response.status_code == 401:
+        if response.status_code == 401 and not isinstance(self.session.auth, BYOTokenAuth):
             logging.info('Updating token and retrying request')
             return self._update_token_and_retry_request(method, url, data=data, params=params,
                                                         headers=request_headers, retry_count=retry_count,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.0
+current_version = 4.0.1
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _KEYWORDS = ' '.join([
 
 setup(
     name='sequoia-client-sdk',
-    version='4.0.0',
+    version='4.0.1',
     description=sequoia.__description__,
     long_description=_LONG_DESCRIPTION,
     long_description_content_type='text/x-rst',

--- a/tests/client_integration_test.py
+++ b/tests/client_integration_test.py
@@ -324,6 +324,70 @@ class TestEndpointProxy(TestGeneric):
         for split in splits:
             assets_endpoint.delete(self.owner, split.tolist())
 
+    def test_refresh_sequoia_token(self):
+        """
+        When you perform a query against Sequoia and your token has expired or it's been invalidated,
+        a new token is taken and used to perform your query.
+        """
+        assets_ids, content_name = self._create_ids_and_content(5)
+        content = content_template % content_name
+        assets = assets_template % assets_ids
+        client = Client(self.registry,
+                        grant_client_id=self.config.sequoia.username,
+                        grant_client_secret=self.config.sequoia.password)
+        content_endpoint = client.metadata.contents
+        assets_endpoint = client.metadata.assets
+        content_endpoint.store(self.owner, content)
+        assets_endpoint.store(self.owner, assets)
+        sleep(1)
+        response = assets_endpoint.browse(
+            self.owner,
+            criteria.Criteria().add(
+                criterion=criteria.StringExpressionFactory.field("contentRef").equal_to(
+                    'testmock:%s' % content_name)))
+        assert_that(response.resources, has_length(5))
+
+        # Revoke the token (not using clientsdk)
+        current_token = client._auth.session.access_token
+        my_auth_creds = 'cGlrc2VsLWNvbXB1dGU6SGVKdjFrSU02WHd6UjU'
+        import requests
+
+        url = "https://identity.sandbox.eu-west-1.palettedev.aws.pikselpalette.com/oauth/revoke"
+        payload = 'token=' + current_token
+        headers = {
+            'authorization': 'Basic ' + my_auth_creds,
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
+
+        response = requests.request("POST", url, headers=headers, data=payload)
+        print('*********************')
+        print(response.text)
+        print('*********************')
+        print(response)
+        print('OLD token: ' + current_token)
+        print('*********************')
+
+        # Query again
+        sleep(5)
+        response = assets_endpoint.browse(
+            self.owner,
+            criteria.Criteria().add(
+                criterion=criteria.StringExpressionFactory.field("contentRef").equal_to(
+                    'testmock:%s' % content_name)))
+        # print(len(response))
+        # assert_that(response.resources, has_length(5))
+
+        print('**************')
+        print('OLD token: ' + current_token)
+        print('NEW token: ' + client._auth.session.access_token)
+        print('**************')
+
+
+        # Clean up
+        content_endpoint.delete(self.owner, 'testmock:' + content_name)
+        for name in assets_ids:
+            assets_endpoint.delete(self.owner, 'testmock:' + name)
+
     def _create_ids_and_content_for_pagination_of_linked(self, ids_number, content_name):
         assets_tuple = zip(tuple(str(uuid.uuid4()) for i in range(0, ids_number)), [content_name] * ids_number)
         assets_flatted_tuple = tuple([element for tupl in assets_tuple for element in tupl])


### PR DESCRIPTION
When a query is performed but the auth token was previously retrieved and it's now expired or revoked, a new token is automatically requested and used for the query requested.